### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -94,7 +94,7 @@ const config: Config = {
           items: [
             {
               label: "Twitter",
-              href: "https://twitter.com/sprinter_ux",
+              href: "https://x.com/sprinter_ux",
             },
             {
               label: "Discord",


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.